### PR TITLE
Feature: Request rewarded video status and receive a message with the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,19 @@ firebase.show_banner_ad(false)	// Hide Banner Ad
 firebase.show_interstitial_ad() // Show Interstitial Ad
 
 firebase.show_rewarded_video()	// Show Rewarded Video Ad
+
+firebase.request_rewarded_video_status() // Request the rewarded video status
 ```
 
 Recive message from java
 
 ```
-func _recive_message(from, key, data):
-	from == "FireBase":
-		if key == "AdMobReward": print("json data with [RewardType & RewardAmount]: ", data);
+func _receive_message(from, key, data):
+	if from == "FireBase":
+		if key == "AdMobReward":
+			print("json data with [RewardType & RewardAmount]: ", data)
+		elif key == "AdMobVideoStatus":
+			print("AdMob rewarded video status is ", data)
 ```
 
 # Log Event

--- a/android/AdMob.java
+++ b/android/AdMob.java
@@ -160,6 +160,10 @@ public class AdMob {
 		requestNewInterstitial();
 	}
 
+	public void emitRewardedVideoStatus() {
+		Utils.callScriptFunc("AdMobVideoStatus", mrv.isLoaded() ? "loaded" : "not_loaded");
+	}
+
 	public void createRewardedVideo() {
 		mrv = MobileAds.getRewardedVideoAdInstance(activity);
 		mrv.setRewardedVideoAdListener(new RewardedVideoAdListener() {
@@ -167,6 +171,7 @@ public class AdMob {
 			@Override
 			public void onRewardedVideoAdLoaded() {
 				Utils.d("AdMob:Video:Loaded");
+				emitRewardedVideoStatus();
 			}
 
 			@Override
@@ -213,6 +218,10 @@ public class AdMob {
 		});
 
 		requestNewRewardedVideo();
+	}
+
+	public void requestRewardedVideoStatus() {
+		emitRewardedVideoStatus();
 	}
 
 	public void show_rewarded_video() {

--- a/android/FireBase.java
+++ b/android/FireBase.java
@@ -56,7 +56,7 @@ public class FireBase extends Godot.SingletonBase {
 			"ask_facebook_read_permission", "ask_facebook_publish_permission",
 			"get_google_user", "get_facebook_user", "google_revoke_access",
 			"facebook_revoke_access", "authConfig", "show_banner_ad",
-			"show_interstitial_ad", "show_rewarded_video", "download", "upload"
+			"show_interstitial_ad", "show_rewarded_video", "request_rewarded_video_status", "download", "upload"
 		});
 
 		activity = p_activity;
@@ -490,6 +490,14 @@ public class FireBase extends Godot.SingletonBase {
 		activity.runOnUiThread(new Runnable() {
 			public void run() {
 				AdMob.getInstance(activity).show_interstitial_ad();
+			}
+		});
+	}
+
+	public void request_rewarded_video_status() {
+		activity.runOnUiThread(new Runnable() {
+			public void run() {
+				AdMob.getInstance(activity).requestRewardedVideoStatus();
 			}
 		});
 	}


### PR DESCRIPTION
This solves #7.

I have tried to have a sync `is_rewarded_video_available` method, but it seems not possible since interaction with rewarded video instance must been done within Main UI's thread. 

So I turned this into an asynchronic solution with two new elements:

### `request_rewarded_video_status` method

You are now able to request rewarded video status by calling `firebase.request_rewarded_video_status()` from Godot. After this you will receive a new message from Firebase module with the status.

Also, if at some point the video was loaded, you will receive a message informing the new status.

### Reciving the `AdMobVideoStatus` message sent by Firebase module

After you call `firebase.request_rewarded_video_status()` or when the video gets loaded, you will receive a `AdMobVideoStatus` message with the status data. The key will be `AdMobVideoStatus` and the value can be either `"loaded"` or `"not_loaded"`.

---

I have updated the readme with this feature too.