### PR TITLE
Fix crash in Remote Config

### DIFF
--- a/config.py
+++ b/config.py
@@ -194,7 +194,7 @@ def update_module(env):
 
     return True
 
-def implement(api, support=True):
+def implement(api, support=False):
     supportv4 = "{exclude group: 'com.android.support' exclude module: 'appcompat-v7' exclude module: 'support-v4'}"
     return "implementation('"+api+"')" + (supportv4 if support else "")
     pass
@@ -240,6 +240,7 @@ def configure(env):
 
         if _config["RemoteConfig"]:
             env.android_add_dependency(implement("com.google.firebase:firebase-config:16.5.0"))
+            env.android_add_dependency(implement("com.android.support:support-v4:28.0.0"))
 
         if _config["Notification"]:
             env.android_add_dependency(implement("com.google.firebase:firebase-messaging:17.6.0"))


### PR DESCRIPTION
When using Remote Config, the following crash occurs at runtime:

05-08 11:05:29.325 19392 19392 E AndroidRuntime: java.lang.NoClassDefFoundError: Failed resolution of: Landroid/support/v4/app/FragmentActivity;

This is because support-v4 is excluded and can not be found. The fix is to not exclude support-v4 and to add the specific support-v4 library. I have found that both parts are needed or you get either a build error or crash on runtime. 

If I try to build all Firebase components, I get the error "The number of method references in a .dex file cannot exceed 64K". This is unrelated to this fix and happens regardless.

