### PR TITLE
Add simple link sharing facility after removal of firebase invites.

### DIFF
--- a/android_src/FireBase.java
+++ b/android_src/FireBase.java
@@ -103,8 +103,12 @@ public class FireBase extends Godot.SingletonBase {
 			//Storage--
 
 			//Firestore++
-			"load_document", "load_document_to", "set_document", "add_document"
+			"load_document", "load_document_to", "set_document", "add_document",
 			//Firestore--
+			
+			//Share++
+			"share"
+			//Share--
 		});
 
 		activity = p_activity;
@@ -742,6 +746,16 @@ public class FireBase extends Godot.SingletonBase {
 		});
 	}
 	//Firestore--
+	
+	//Sharing++
+	public void share(final String p_text, final String p_subject) {
+		activity.runOnUiThread(new Runnable() {
+			public void run() {
+				Share.getInstance(activity).share(p_text, p_subject);
+			}
+		});
+	}
+	//Sharing--
 
 	/** Main Funcs **/
 	public static JSONObject getConfig() {

--- a/android_src/Share.java
+++ b/android_src/Share.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2019 BunbySoft. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+package org.godotengine.godot;
+
+import android.app.Activity;
+import android.content.Intent;
+import com.google.firebase.FirebaseApp;
+
+public class Share {	
+	public static Share getInstance(Activity p_activity) {
+		if (mInstance == null) {
+			mInstance = new Share(p_activity);
+		}
+		return mInstance;
+	}
+	
+	public Share (Activity p_activity) {
+		activity = p_activity;
+	}
+	
+	public void init (FirebaseApp firebaseApp) {
+		mFirebaseApp = firebaseApp;
+	}
+	
+	public void share(String text, String subject) {
+		Intent sendIntent = new Intent();
+		sendIntent.setAction(Intent.ACTION_SEND);
+		sendIntent.putExtra(Intent.EXTRA_TEXT, text);
+		if (subject != null && !subject.isEmpty()) {
+			sendIntent.putExtra(Intent.EXTRA_SUBJECT, subject);
+		}
+		sendIntent.setType("text/plain");
+		activity.startActivity(sendIntent);
+	}
+
+	private static Activity activity = null;
+	private static Share mInstance = null;
+
+	private FirebaseApp mFirebaseApp = null;
+}

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ _config = {
 "Notification"   : True,
 "Storage"        : False,
 "Firestore"      : True,
+"Share"          : True,
 
 "Authentication" : True,
 "AuthGoogle"     : True,
@@ -128,7 +129,7 @@ def update_module(env):
 
     data_to_check = \
     ["Analytics", "AdMob", "Auth", "Notification", "RemoteConfig",\
-    "Storage", "Firestore", "AuthFacebook", "AuthGoogle", "AuthTwitter"]
+    "Storage", "Firestore", "Share", "AuthFacebook", "AuthGoogle", "AuthTwitter"]
 
     regex_list = []
 

--- a/helper.py
+++ b/helper.py
@@ -12,6 +12,7 @@ FILES_LIST		= \
 "RemoteConfig"	: ["RemoteConfig.java"],
 "Storage"	: ["storage/"],
 "Firestore"	: ["Firestore.java"],
+"Share"         : ["Share.java"],
 
 "AuthGoogle"    : ["GoogleSignIn.java"],
 "AuthFacebook"  : ["FacebookSignIn.java"],


### PR DESCRIPTION
Firebase invites may be depreciated, but some people may still want to have a simple share link facility. This does not use "invites" so is still OK to use.